### PR TITLE
Git add --all for git versions < 2.0

### DIFF
--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -152,7 +152,7 @@ class GitSync extends Git
             $paths[] = $folder;
         }
 
-        if (version_compare($version, '1.8.1.4', '<')) {
+        if (version_compare($version, '2.0', '<')) {
             $add .= ' --all';
         }
 


### PR DESCRIPTION
Git add . doesn't work for deleted files if git version is lower than 2.0. So it should use git add --all instead.