### PR TITLE
Add route and location to fix plugins_quick_tray permission

### DIFF
--- a/git-sync.php
+++ b/git-sync.php
@@ -85,6 +85,8 @@ class GitSyncPlugin extends Plugin
             //            'route' => $this->admin_route . '/plugins/tntsearch',
             'hint' => 'Synchronize GitSync',
             'class' => 'gitsync-sync',
+            'location' => 'pages',
+            'route' => 'admin',
             'data'  => [
                 'gitsync-useraction' => 'sync',
                 'gitsync-uri' => $base . '/plugins/git-sync'


### PR DESCRIPTION
- let the user with access to admin.pages also have access to git-sync

Previously only admin users with admin.super access could use git-sync.

Fixes trilbymedia/grav-plugin-git-sync#78