### PR TITLE
Added Git Sync triggerable on all admin events

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -30,7 +30,7 @@ form:
       validate:
         type: bool
     folders:
-      type: hidden
+      type: selectize
       multiple: true
       size: medium
       label: Sync Folders
@@ -108,6 +108,17 @@ form:
       default: 0
       label: Log Git Commands
       help: Logs git commands. Useful to debug and troubleshoot git execution
+      highlight: 0
+      options:
+          1: PLUGIN_ADMIN.YES
+          0: PLUGIN_ADMIN.NO
+      validate:
+          type: bool
+    sync_on_all_admin_save_events:
+      type: toggle
+      default: 0
+      label: Sync on all admin save events
+      help: If No, synchronization will be fired only on page/folder/media save events.
       highlight: 0
       options:
           1: PLUGIN_ADMIN.YES

--- a/git-sync.php
+++ b/git-sync.php
@@ -194,10 +194,13 @@ class GitSyncPlugin extends Plugin
     {
         $obj           = $event['object'];
         $isPluginRoute = $this->grav['uri']->path() == '/admin/plugins/' . $this->name;
+        $config        = $this->config->get('plugins.' . $this->name);
 
         if ($obj instanceof Data) {
             if (!$isPluginRoute || !Helper::isGitInstalled()) {
-                return true;
+                if (!isset($config['sync_on_all_admin_save_events']) || !$config['sync_on_all_admin_save_events']) {
+                    return true;
+                }
             } else {
                 // empty password, keep current one or encrypt if haven't already
                 $password = $obj->get('password', false);
@@ -223,6 +226,7 @@ class GitSyncPlugin extends Plugin
     {
         $obj           = $event['object'];
         $isPluginRoute = $this->grav['uri']->path() == '/admin/plugins/' . $this->name;
+        $config        = $this->config->get('plugins.' . $this->name);
 
         /*
         $folders = $this->controller->git->getConfig('folders', []);
@@ -233,7 +237,9 @@ class GitSyncPlugin extends Plugin
 
         if ($obj instanceof Data) {
             if (!$isPluginRoute || !Helper::isGitInstalled()) {
-                return true;
+                if (!isset($config['sync_on_all_admin_save_events']) || !$config['sync_on_all_admin_save_events']) {
+                    return true;
+                }
             } else {
                 $this->controller->git->setConfig($obj);
 

--- a/git-sync.yaml
+++ b/git-sync.yaml
@@ -1,2 +1,1 @@
 enabled: true
-text_var: Custom Text added by the **Git Sync** plugin (disable plugin to remove)


### PR DESCRIPTION
This proposal add an option in the plugin to trigger a synchronization on all admin save event.
I also display the folder option in the blueprint to help parametrize witch folder we want to synchronize.

The initial goal was to get a website always sync with a git repo (almost the whole `/user` content). The actual plugin only trigger a sync on page save events whereas we can change configurations and use plugins in the Admin BO.

The only con of this feature is that it add latency to all admin save action (not only in the page module). But maybe this is related to remote git latency...