### PR TITLE
Make consistent usage of repositoryPath in GitSync class and make the…

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -42,6 +42,12 @@ form:
       validate:
         type: commalist
     repository:
+      type: hidden
+      multiple: false
+      size: medium
+      label: Local reposetory path
+      default: user
+    repository:
       type: text
       label: Git Repository
       placeholder: https://github.com/user/repository.git

--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -18,11 +18,11 @@ class GitSync extends Git
 
     public function __construct(Plugin $plugin = null)
     {
-        parent::__construct(USER_DIR);
-        static::$instance = $this;
         $this->grav = Grav::instance();
         $this->config = $this->grav['config']->get('plugins.git-sync');
-        $this->repositoryPath = USER_DIR;
+        $this->repositoryPath = $this->config['repository_path'];
+        parent::__construct($this->repositoryPath);
+        static::$instance = $this;
 
         $this->user = isset($this->config['user']) ? $this->config['user'] : null;
         $this->password = isset($this->config['password']) ? $this->config['password'] : null;
@@ -135,7 +135,7 @@ class GitSync extends Git
             $sparse[] = $folder . '/*';
         }
 
-        $file = File::instance(rtrim(USER_DIR, '/') . '/.git/info/sparse-checkout');
+        $file = File::instance(rtrim($this->repositoryPath, '/') . '/.git/info/sparse-checkout');
         $file->save(implode("\r\n", $sparse));
         $file->free();
 
@@ -144,7 +144,7 @@ class GitSync extends Git
             $ignore[] = '!/' . $folder;
         }
 
-        $file = File::instance(rtrim(USER_DIR, '/') . '/.gitignore');
+        $file = File::instance(rtrim($this->repositoryPath, '/') . '/.gitignore');
         $file->save(implode("\r\n", $ignore));
         $file->free();
     }


### PR DESCRIPTION
… repository path configurable.

Background of this is, that by making the repository path of the sync directory configurable, you can define a path like: user/git-sync
This way, the content repo is outside the user root, which in many cases is part of a global git repo. Moving the pages directory (and any other directory defined in "folders" of git-sync) to this custom defined git-sync directory and adding symlinks to the user directory itself to keep Grav running seems a solid solution to this for me.

You will end up with smth. linke that:
/
/user/pages -> symlink to /user/git-sync/pages
/user
/user/git-sync
/user/git-sync/pages

But that only works by changing the repository path of git-sync.

Similar issues have been discussed in:
https://github.com/trilbymedia/grav-plugin-git-sync/issues/54
https://github.com/trilbymedia/grav-plugin-git-sync/issues/33
https://github.com/trilbymedia/grav-plugin-git-sync/issues/25