### PR TITLE
Added options to disable automatic sync on save/delete/media.

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -59,6 +59,48 @@ form:
       label: Repository Web Hook
       placeholder: /_git-sync
       default: /_git-sync
+    Sync:
+      type: section
+      title: Synchronization
+      underline: true
+    SyncWarning:
+      type: spacer
+      text: |
+        Warning: if these options are disabled, automatic sync will not occurs at all when a page is saved, or others triggers, according to what you disabled. But it may improve performances if saving pages is too slow.<br />
+        Without any further action, nothing will be comitted to git. We recommand you to either sync manually using the <i class="fa fa-git"></i> Sync button in the top left of the administration panel, or setup a periodic task to sync with the remote repository every few hours in the background.
+    sync.on_save:
+      type: toggle
+      label: Sync On Save
+      help: Sync with the remote directory when a page is saved through the admin
+      default: 1
+      highlight: 1
+      options:
+        1: PLUGIN_ADMIN.YES
+        0: PLUGIN_ADMIN.NO
+      validate:
+        type: bool
+    sync.on_delete:
+      type: toggle
+      label: Sync On Delete
+      help: Sync with the remote directory when a page is deleted through the admin
+      default: 1
+      highlight: 1
+      options:
+        1: PLUGIN_ADMIN.YES
+        0: PLUGIN_ADMIN.NO
+      validate:
+        type: bool
+    sync.on_media:
+      type: toggle
+      label: Sync When Media are Uploaded or Deleted
+      help: Sync with the remote directory when a media is uploaded or deleted through the admin immediatly (instead of only syncing when the page is saved)
+      default: 1
+      highlight: 1
+      options:
+        1: PLUGIN_ADMIN.YES
+        0: PLUGIN_ADMIN.NO
+      validate:
+        type: bool
     Advanced:
       type: section
       title: Advanced

--- a/git-sync.php
+++ b/git-sync.php
@@ -47,10 +47,10 @@ class GitSyncPlugin extends Plugin
                 'onAdminMenu'          => ['onAdminMenu', 0],
                 'onAdminSave'          => ['onAdminSave', 0],
                 'onAdminAfterSave'     => ['onAdminAfterSave', 0],
-                'onAdminAfterSaveAs'   => ['synchronize', 0],
-                'onAdminAfterDelete'   => ['synchronize', 0],
-                'onAdminAfterAddMedia' => ['synchronize', 0],
-                'onAdminAfterDelMedia' => ['synchronize', 0],
+                'onAdminAfterSaveAs'   => ['onAdminAfterSaveAs', 0],
+                'onAdminAfterDelete'   => ['onAdminAfterDelete', 0],
+                'onAdminAfterAddMedia' => ['onAdminAfterMedia', 0],
+                'onAdminAfterDelMedia' => ['onAdminAfterMedia', 0],
             ]);
 
             return;
@@ -186,8 +186,6 @@ class GitSyncPlugin extends Plugin
             $this->controller->execute();
             $this->controller->redirect();
         }
-
-
     }
 
     public function onAdminSave($event)
@@ -221,6 +219,10 @@ class GitSyncPlugin extends Plugin
 
     public function onAdminAfterSave($event)
     {
+        if (!$this->grav['config']->get('plugins.git-sync.sync.on_save', true)) {
+            return true;
+        }
+
         $obj           = $event['object'];
         $isPluginRoute = $this->grav['uri']->path() == '/admin/plugins/' . $this->name;
 
@@ -247,6 +249,33 @@ class GitSyncPlugin extends Plugin
         }
 
         $this->synchronize();
+
+        return true;
+    }
+
+    public function onAdminAfterSaveAs()
+    {
+        if ($this->grav['config']->get('plugins.git-sync.sync.on_save', true)) {
+            $this->synchronize();
+        }
+
+        return true;
+    }
+
+    public function onAdminAfterDelete()
+    {
+        if ($this->grav['config']->get('plugins.git-sync.sync.on_delete', true)) {
+            $this->synchronize();
+        }
+
+        return true;
+    }
+
+    public function onAdminAfterMedia()
+    {
+        if ($this->grav['config']->get('plugins.git-sync.sync.on_media', true)) {
+            $this->synchronize();
+        }
 
         return true;
     }


### PR DESCRIPTION
If the corresponding options are disabled, sync will not occur when the user saves pages, delete them, or upload/remove media.

These parameters could be used to fix performances issues due to the git pull/push
being synchronously executed when pages are saved, implying way too long loading times. But sync must be done manually or using a cron if auto sync is disabled (obviously).

I also added a warning about that in the configuration page, just above the new sync options.

The new sync options are enabled by default, so if an existing installation is updated, the behaviour will not change at all.

If you want, I can tailor the options (if you want more or less granularity), and update the changelog.

Fixes #51.