### PR TITLE
Adding support for use of the RHEL/CentOS Software Collection Library

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -151,6 +151,11 @@ form:
       label: Git Binary Path
       help: If the default `git` command doesn't work on your machine or if you want to specify a custom path, do it in here
       placeholder: /usr/bin/git
+    git.scl:
+      type: text
+      label: Prefix For Command
+      help: If running in an environment that using software collections, enable git here
+      placeholder: scl enable rh-git29
     logging:
       type: toggle
       default: 0

--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -311,7 +311,7 @@ class GitSync extends Git
 
             if (DIRECTORY_SEPARATOR == '/') {
                 if ($prefix = $this->getGitConfig('scl', null)) {
-                    $command = $prefix . ' \'' . $command . '\'';
+                    $command = $prefix . ' \'' . addcslashes($command, '\'') . '\'';
                 }
 
                 $command = 'LC_ALL=en_US.UTF-8 ' . $command;

--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -310,6 +310,10 @@ class GitSync extends Git
             $command .= ' 2>&1';
 
             if (DIRECTORY_SEPARATOR == '/') {
+                if ($prefix = $this->getGitConfig('scl', null)) {
+                    $command = $prefix . ' \'' . $command . '\'';
+                }
+
                 $command = 'LC_ALL=en_US.UTF-8 ' . $command;
             }
 


### PR DESCRIPTION
When using RHEL or CentOS you have to use the SCL to get a newer version of git. Running git without SCL fails in this situation.

This provides for ability to enable the SCL.