### PR TITLE
Allow setting a personalised commit message

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -204,6 +204,13 @@ form:
         gitsync: Use GitSync Committer Name
         gravuser: Use Grav User Name
         gravfull: Use Grav User Full Name
+        
+    git.message:
+      type: text
+      default: (Grav GitSync) Automatic Commit
+      label: Commit message
+      placeholder: (Grav GitSync) Automatic Commit
+      help: You can use {{pageTitle}} or {{pageRoute}} in your message as placeholders for the title or route of the page being saved
 
     git.name:
       type: text

--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -218,6 +218,17 @@ class GitSync extends Git
         if (defined('GRAV_CLI') && in_array($authorType, ['gravuser', 'gravfull'])) {
             $authorType = 'gituser';
         }
+        
+        // get message from config, it any, or stick to the default one
+        $message = $this->getConfig('git', null)['message'] ?? $message;
+
+        // get Page Title and Route from Post
+        $pageTitle = $_POST['data']['header']['title']??'NO TITLE FOUND';
+        $pageRoute = $_POST['data']['route']??'NO ROUTE FOUND';
+
+        // include page title and route in the message, if placeholders exist
+        $message = str_replace( '{{pageTitle}}', $pageTitle, $message );
+        $message = str_replace( '{{pageRoute}}', $pageRoute, $message );
 
         switch ($authorType) {
             case 'gitsync':


### PR DESCRIPTION
* Update plugin blueprint to
    * Add new **git.message** config setting, that allows users to set their own automatic commit message
    * This message supports using {{pageTitle}} and {{pageroute}} as placeholders for information from the saved page
* Updated GitSync class to
    * Set the commit message using the new **git.message** config setting
    * Get data from the posted/saved page, to replace the {{pageTitle}} and {{pageRoute}} placeholders in the message