### PR TITLE
Update GitSync.php. Changed locale definition.

### DIFF
--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -338,7 +338,7 @@ class GitSync extends Git
             $command .= ' 2>&1';
 
             if (DIRECTORY_SEPARATOR == '/') {
-                $command = 'LC_ALL=en_US.UTF-8 ' . $command;
+                $command = 'LC_ALL=C ' . $command;
             }
 
             if ($this->getConfig('logging', false)) {


### PR DESCRIPTION
`LC_ALL=en_US.UTF-8` - does not always give the desired result.
`LC_ALL=C` - more reliable.

See [Issue #124](https://github.com/trilbymedia/grav-plugin-git-sync/issues/124).