### PR TITLE
Add Initiate CLI command

### DIFF
--- a/cli/InitCommand.php
+++ b/cli/InitCommand.php
@@ -1,22 +1,21 @@
-<?php
-namespace Grav\Plugin\Console;
+<?php namespace Grav\Plugin\Console;
 
 use Grav\Console\ConsoleCommand;
 use Grav\Plugin\GitSync\GitSync;
 
 /**
- * Class LogCommand
+ * Class Initommand
  *
  * @package Grav\Plugin\Console
  */
-class InitiateCommand extends ConsoleCommand
+class InitCommand extends ConsoleCommand
 {
     protected function configure()
     {
         $this
-            ->setName('initiate')
-            ->setDescription('Performs a initialization of your git repository')
-            ->setHelp('The <info>initiate</info> command runs the same git commands as the onAdminAfterSave function. Use this to manually reinitialise git-sync (useful for automated deployments).')
+            ->setName('init')
+            ->setDescription('Initializes your git repository')
+            ->setHelp('The <info>init</info> command runs the same git commands as the onAdminAfterSave function. Use this to manually initialise git-sync (useful for automated deployments).')
         ;
     }
 

--- a/cli/InitiateCommand.php
+++ b/cli/InitiateCommand.php
@@ -1,0 +1,46 @@
+<?php
+namespace Grav\Plugin\Console;
+
+use Grav\Console\ConsoleCommand;
+use Grav\Plugin\GitSync\GitSync;
+
+/**
+ * Class LogCommand
+ *
+ * @package Grav\Plugin\Console
+ */
+class InitiateCommand extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('initiate')
+            ->setDescription('Performs a initialization of your git repository')
+            ->setHelp('The <info>initiate</info> command runs the same git commands as the onAdminAfterSave function. Use this to manually reinitialise the gitsync (useful for automated deployments).')
+        ;
+    }
+
+    protected function serve()
+    {
+        require_once __DIR__ . '/../vendor/autoload.php';
+
+        $plugin = new GitSync();
+        $repository = $plugin->getConfig('repository', false);
+
+        $this->output->writeln('');
+
+        if (!$repository) {
+            $this->output->writeln('<red>ERROR:</red> No repository has been configured');
+        }
+
+        $this->output->writeln('Initialising <cyan>' . $repository . '</cyan>');
+
+        $this->output->write('Starting Initialisation...');
+
+        $plugin->initializeRepository();
+        $plugin->setUser();
+        $plugin->addRemote();
+
+        $this->output->writeln('completed.');
+    }
+}

--- a/cli/InitiateCommand.php
+++ b/cli/InitiateCommand.php
@@ -16,7 +16,7 @@ class InitiateCommand extends ConsoleCommand
         $this
             ->setName('initiate')
             ->setDescription('Performs a initialization of your git repository')
-            ->setHelp('The <info>initiate</info> command runs the same git commands as the onAdminAfterSave function. Use this to manually reinitialise the gitsync (useful for automated deployments).')
+            ->setHelp('The <info>initiate</info> command runs the same git commands as the onAdminAfterSave function. Use this to manually reinitialise git-sync (useful for automated deployments).')
         ;
     }
 


### PR DESCRIPTION
Added a CLI command to initialise git-sync. This is useful for automated deployments and Docker images where git-sync needs to be initialised before first run.

Should close issue #13 .