### PR TITLE
Don't accept webhooks when they are disabled in config

### DIFF
--- a/git-sync.php
+++ b/git-sync.php
@@ -98,8 +98,8 @@ class GitSyncPlugin extends Plugin
         $secret = $config['webhook_secret'] ?? false;
         $enabled = $config['webhook_enabled'] ?? false;
 
-        if ($route === $webhook && $_SERVER['REQUEST_METHOD'] === 'POST') {
-            if ($secret && $enabled) {
+        if ($enabled && $route === $webhook && $_SERVER['REQUEST_METHOD'] === 'POST') {
+            if ($secret) {
                 if (!$this->isRequestAuthorized($secret)) {
                     http_response_code(401);
                     header('Content-Type: application/json');


### PR DESCRIPTION
I confess this is untested as I don't have any repos handy I want to risk on a test. Should probably be an issue, but since I can see what should be the fix, here it is as a PR. I'm working on a heavily modified fork, so noticed this when refactoring.

Unless I'm mistaken, it seems that webhook requests receive answers when `webhook_enabled` is set false. That's because they bypass the test on line 102. That would trigger a sync attempt. Not sure if much harm can come from that, but it seems like a hole.

Moved the condition up a level to prevent it. I assume 404 would be the response when disabled and this is what you'd want.