### PR TITLE
Add posibility to syncronize only in one direction

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -37,6 +37,15 @@ form:
       validate:
         type: bool
 
+    sync.direction:
+      type: select
+      label: Sync direction
+      size: medium
+      default: both
+      options:
+        pull: One-way (Pull only)
+        both: Both-ways (Pull and Push)
+
     folders:
       type: select
       multiple: true

--- a/classes/GitSync.php
+++ b/classes/GitSync.php
@@ -404,7 +404,9 @@ class GitSync extends Git
 
         $this->fetch($name, $branch);
         $this->pull($name, $branch);
-        $this->push($name, $branch);
+        if ($this->grav['config']->get('plugins.git-sync.sync.direction', 'both') == 'both') {
+            $this->push($name, $branch);
+        }
 
         $this->addRemote();
 

--- a/git-sync.php
+++ b/git-sync.php
@@ -398,6 +398,7 @@ class GitSyncPlugin extends Plugin
 
             if ($isPluginRoute) {
                 $this->git->setConfig($obj->toArray());
+                $this->config->reload();
 
                 // initialize git if not done yet
                 $this->git->initializeRepository();


### PR DESCRIPTION
This patch adds a configuration switch to enable one-way (pull only) synchronization. This is useful in cases where git master repository is protected from direct pushes, e.g. all changes must come via pull requests.