### PR TITLE
Use {$var} instead of ${var}

### DIFF
--- a/classes/Helper.php
+++ b/classes/Helper.php
@@ -77,7 +77,7 @@ class Helper
             return $repository;
         }
 
-        return str_replace('://', "://${user}${password}@", $repository);
+        return str_replace('://', "://{$user}{$password}@", $repository);
     }
 
     /**


### PR DESCRIPTION
I'm using PHP 8.3. This fixes a deprecation warning of ${var}. It looks like an oversight since the rest of the repo already seems to have been transitioned.